### PR TITLE
Fix "modules not found" warnings

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,7 @@ const nextConfig = {
         fs: false,
       };
     }
+    config.externals.push("pino-pretty", "encoding");
     return config;
   },
   images: {
@@ -30,4 +31,4 @@ const nextConfig = {
   },
 };
 
-export default nextConfig
+export default nextConfig;


### PR DESCRIPTION
When running `pnpm dev`, several warnings were shown regarding the modules "pino-pretty" and "encoding" not being found.

These are shown when the Next.js configuration of WalletConnect/Reown is incomplete.

More info here
https://docs.reown.com/appkit/next/core/installation#extra-configuration

Warnings:

```
[manumonti@Manuels-MacBook-Pro:~/Projects/nucypher/taco-orbisdb-demo on main]
% pnpm dev                                                                                                                                                       ✹

> new-forum@0.1.0 dev /Users/manumonti/Projects/nucypher/taco-orbisdb-demo
> next dev

  ▲ Next.js 14.2.4
  - Local:        http://localhost:3000
  - Environments: .env.local

 ✓ Starting...
 ✓ Ready in 4s
 ○ Compiling / ...
 ⚠ ./node_modules/.pnpm/@metamask+sdk@0.29.3_bufferutil@4.0.8_react-dom@18.3.1_react@18.3.1__react-native@0.75.4_@bab_cr3ljl2ggshgpyvxbqapr3sndu/node_modules/@metamask/sdk/dist/node/es/metamask-sdk.js
Module not found: Can't resolve 'encoding' in '/Users/manumonti/Projects/nucypher/taco-orbisdb-demo/node_modules/.pnpm/@metamask+sdk@0.29.3_bufferutil@4.0.8_react-dom@18.3.1_react@18.3.1__react-native@0.75.4_@bab_cr3ljl2ggshgpyvxbqapr3sndu/node_modules/@metamask/sdk/dist/node/es'

Import trace for requested module:
./node_modules/.pnpm/@metamask+sdk@0.29.3_bufferutil@4.0.8_react-dom@18.3.1_react@18.3.1__react-native@0.75.4_@bab_cr3ljl2ggshgpyvxbqapr3sndu/node_modules/@metamask/sdk/dist/node/es/metamask-sdk.js
./node_modules/.pnpm/@wagmi+connectors@5.2.1_@types+react@18.3.3_@wagmi+core@2.13.8_@tanstack+query-core@5.59.13_@_wtcnakt4puqjiq3nuomedchiia/node_modules/@wagmi/connectors/dist/esm/metaMask.js
./node_modules/.pnpm/@wagmi+connectors@5.2.1_@types+react@18.3.3_@wagmi+core@2.13.8_@tanstack+query-core@5.59.13_@_wtcnakt4puqjiq3nuomedchiia/node_modules/@wagmi/connectors/dist/esm/exports/index.js
./node_modules/.pnpm/wagmi@2.12.19_@tanstack+query-core@5.59.13_@tanstack+react-query@5.59.15_react@18.3.1__@types_lafxc5hi6tqm7axvkanqzabr64/node_modules/wagmi/dist/esm/exports/connectors.js
./node_modules/.pnpm/@rainbow-me+rainbowkit@2.2.0_@tanstack+react-query@5.59.15_react@18.3.1__@types+react@18.3.3__sishxooilebddabaqgw6fvgbgm/node_modules/@rainbow-me/rainbowkit/dist/index.js
./components/layout/navbar.tsx

./node_modules/.pnpm/pino@7.11.0/node_modules/pino/lib/tools.js
Module not found: Can't resolve 'pino-pretty' in '/Users/manumonti/Projects/nucypher/taco-orbisdb-demo/node_modules/.pnpm/pino@7.11.0/node_modules/pino/lib'

Import trace for requested module:
./node_modules/.pnpm/pino@7.11.0/node_modules/pino/lib/tools.js
./node_modules/.pnpm/pino@7.11.0/node_modules/pino/pino.js
./node_modules/.pnpm/@walletconnect+logger@2.1.2/node_modules/@walletconnect/logger/dist/index.es.js
./node_modules/.pnpm/@walletconnect+core@2.17.1_bufferutil@4.0.8_utf-8-validate@5.0.10/node_modules/@walletconnect/core/dist/index.es.js
./node_modules/.pnpm/@thirdweb-dev+wallets@2.5.39_@ethersproject+abstract-provider@5.7.0_@ethersproject+abstract-s_3pg6xgtv3iyejbsn22vy653hxi/node_modules/@thirdweb-dev/wallets/dist/thirdweb-dev-wallets.esm.js
./node_modules/.pnpm/@thirdweb-dev+react@4.9.4_tre3kfyovzxjy7h7lrxe2osnua/node_modules/@thirdweb-dev/react/dist/thirdweb-dev-react.esm.js
./app/layout.tsx
 GET / 200 in 18268ms
 ⚠ ./node_modules/.pnpm/@metamask+sdk@0.29.3_bufferutil@4.0.8_react-dom@18.3.1_react@18.3.1__react-native@0.75.4_@bab_cr3ljl2ggshgpyvxbqapr3sndu/node_modules/@metamask/sdk/dist/node/es/metamask-sdk.js
Module not found: Can't resolve 'encoding' in '/Users/manumonti/Projects/nucypher/taco-orbisdb-demo/node_modules/.pnpm/@metamask+sdk@0.29.3_bufferutil@4.0.8_react-dom@18.3.1_react@18.3.1__react-native@0.75.4_@bab_cr3ljl2ggshgpyvxbqapr3sndu/node_modules/@metamask/sdk/dist/node/es'

Import trace for requested module:
./node_modules/.pnpm/@metamask+sdk@0.29.3_bufferutil@4.0.8_react-dom@18.3.1_react@18.3.1__react-native@0.75.4_@bab_cr3ljl2ggshgpyvxbqapr3sndu/node_modules/@metamask/sdk/dist/node/es/metamask-sdk.js
./node_modules/.pnpm/@wagmi+connectors@5.2.1_@types+react@18.3.3_@wagmi+core@2.13.8_@tanstack+query-core@5.59.13_@_wtcnakt4puqjiq3nuomedchiia/node_modules/@wagmi/connectors/dist/esm/metaMask.js
./node_modules/.pnpm/@wagmi+connectors@5.2.1_@types+react@18.3.3_@wagmi+core@2.13.8_@tanstack+query-core@5.59.13_@_wtcnakt4puqjiq3nuomedchiia/node_modules/@wagmi/connectors/dist/esm/exports/index.js
./node_modules/.pnpm/wagmi@2.12.19_@tanstack+query-core@5.59.13_@tanstack+react-query@5.59.15_react@18.3.1__@types_lafxc5hi6tqm7axvkanqzabr64/node_modules/wagmi/dist/esm/exports/connectors.js
./node_modules/.pnpm/@rainbow-me+rainbowkit@2.2.0_@tanstack+react-query@5.59.15_react@18.3.1__@types+react@18.3.3__sishxooilebddabaqgw6fvgbgm/node_modules/@rainbow-me/rainbowkit/dist/index.js
./components/layout/navbar.tsx

./node_modules/.pnpm/pino@7.11.0/node_modules/pino/lib/tools.js
Module not found: Can't resolve 'pino-pretty' in '/Users/manumonti/Projects/nucypher/taco-orbisdb-demo/node_modules/.pnpm/pino@7.11.0/node_modules/pino/lib'

Import trace for requested module:
./node_modules/.pnpm/pino@7.11.0/node_modules/pino/lib/tools.js
./node_modules/.pnpm/pino@7.11.0/node_modules/pino/pino.js
./node_modules/.pnpm/@walletconnect+logger@2.1.2/node_modules/@walletconnect/logger/dist/index.es.js
./node_modules/.pnpm/@walletconnect+core@2.17.1_bufferutil@4.0.8_utf-8-validate@5.0.10/node_modules/@walletconnect/core/dist/index.es.js
./node_modules/.pnpm/@thirdweb-dev+wallets@2.5.39_@ethersproject+abstract-provider@5.7.0_@ethersproject+abstract-s_3pg6xgtv3iyejbsn22vy653hxi/node_modules/@thirdweb-dev/wallets/dist/thirdweb-dev-wallets.esm.js
./node_modules/.pnpm/@thirdweb-dev+react@4.9.4_tre3kfyovzxjy7h7lrxe2osnua/node_modules/@thirdweb-dev/react/dist/thirdweb-dev-react.esm.js
./app/layout.tsx
```
